### PR TITLE
Use `build-std` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The Playdate SDK installed in `$HOME/Developer/PlaydateSDK`.
 
 Rust, easiest installed via [rustup](https://rustup.rs)
 
-[cargo-xbuild](https://github.com/rust-osdev/cargo-xbuild), installed with `cargo install cargo-xbuild`, if you want to build for the Playdate device rather than the simulator.
+Rust toolchains __nightly__ needed for [build-std][] feature, installed with `rustup install nightly && rustup component add rust-src --toolchain nightly`, if you want to build for the Playdate device rather than the simulator.
+
+[build-std]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,7 +473,7 @@ impl Build {
         let current_dir = std::env::current_dir()?;
         let manifest_path_str;
         let mut args = if self.device {
-            vec!["xbuild"]
+            vec!["+nightly", "build", "-Z", "build-std"]
         } else {
             vec!["build"]
         };


### PR DESCRIPTION
Get rid of `xbuild` and use nightly `build-std` builtin feature.
Closes #7.
@rtsuk, please test native build on the real device if possible.
