### PR TITLE
Don't fail on game directory creation on device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crank"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Rob Tsuk <robtsuk@google.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,7 +361,7 @@ impl Build {
         let games_dir = data_path.join("Games");
         let game_device_dir = format!("{}.pdx", example_title);
         let games_target_dir = games_dir.join(&game_device_dir);
-        fs::create_dir(&games_target_dir).context("Creating game directory on device")?;
+        fs::create_dir(&games_target_dir).ok();
         Self::copy_directory(&pdx_dir, &games_target_dir)?;
 
         let mut cmd = Command::new("diskutil");


### PR DESCRIPTION
I don't think this used to be an error, but it will fail
later if the games directory isn't there.